### PR TITLE
Fix sample ID prefixing and trim whitespace

### DIFF
--- a/app/metadatalib/src/metadatalib/musthave.py
+++ b/app/metadatalib/src/metadatalib/musthave.py
@@ -58,7 +58,10 @@ def fix_time_collected(t: Table, colname: str, pattern: str):
 
 
 def fix_sample_start(t: Table, colname: str, pattern: str):
-    t.data[colname] = [f"S{v}" for v in t.get(colname)]
+    regex = re.compile(pattern)
+    t.data[colname] = [
+        f"S{v}" if v and not regex.match(v) else v for v in t.get(colname)
+    ]
 
 
 def fix_subject_start(t: Table, colname: str, pattern: str):

--- a/app/metadatalib/src/metadatalib/table.py
+++ b/app/metadatalib/src/metadatalib/table.py
@@ -134,4 +134,6 @@ def run_checks(
 
 
 def run_fixes(t: Table, specification: MustHave = specification):
+    for h in t.colnames():
+        specification.append(no_leading_trailing_whitespace(h))
     specification.fix(t)


### PR DESCRIPTION
## Summary
- correct `fix_sample_start` so it only prefixes invalid sample IDs
- have `run_fixes` strip whitespace from all columns before applying fixes

## Testing
- `black .`
- `pytest app/metadatalib/tests`

------
https://chatgpt.com/codex/tasks/task_e_687a792f4b1883238e31005f758ffcef