### PR TITLE
Add column name fix

### DIFF
--- a/app/metadatalib/src/metadatalib/musthave.py
+++ b/app/metadatalib/src/metadatalib/musthave.py
@@ -71,3 +71,11 @@ def fix_subject_start(t: Table, colname: str, pattern: str):
 def fix_disallowed_sample_chars(t: Table, colname: str, pattern: str):
     raw_expression = re.sub(r"[\^\$\[\]\+]", "", pattern)
     t.data[colname] = [re.sub(f"[^{raw_expression}]", ".", v) for v in t.get(colname)]
+
+
+def fix_column_names(t: Table):
+    """Sanitize column names to include only alphanumeric characters, ``_`` and ``-``."""
+    for col in list(t.colnames()):
+        new_col = re.sub(r"[^0-9A-Za-z_-]", "", col)
+        if new_col != col:
+            t.data[new_col] = t.data.pop(col)

--- a/app/metadatalib/src/metadatalib/musthave.py
+++ b/app/metadatalib/src/metadatalib/musthave.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 from datetime import datetime
 from tablemusthave import Table
 
@@ -77,5 +78,11 @@ def fix_column_names(t: Table):
     """Sanitize column names to include only alphanumeric characters, ``_`` and ``-``."""
     for col in list(t.colnames()):
         new_col = re.sub(r"[^0-9A-Za-z_-]", "", col)
+        if not new_col:
+            new_col = "unnamed_column"
         if new_col != col:
+            if new_col in t.data:
+                warnings.warn(
+                    f"Renaming column '{col}' to '{new_col}' overwrites existing column"
+                )
             t.data[new_col] = t.data.pop(col)

--- a/app/metadatalib/src/metadatalib/spec.py
+++ b/app/metadatalib/src/metadatalib/spec.py
@@ -18,6 +18,7 @@ from metadatalib.consts import (
 from metadatalib.musthave import (
     fix_date_collected,
     fix_disallowed_sample_chars,
+    fix_column_names,
     fix_sample_start,
     fix_subject_start,
     fix_time_collected,
@@ -50,7 +51,7 @@ def allowed_file(filename: str) -> bool:
 
 
 common_specs = [
-    columns_matching("^[0-9A-Za-z_.]+$"),
+    columns_matching("^[0-9A-Za-z_-]+$", fix_fn=fix_column_names),
     values_matching("SampleID", "^[A-Za-z]", fix_fn=fix_sample_start),
     values_matching("SampleID", "^[0-9A-Za-z._]+$", fix_fn=fix_disallowed_sample_chars),
     unique_values_for("SampleID"),

--- a/app/metadatalib/tests/test_spec.py
+++ b/app/metadatalib/tests/test_spec.py
@@ -1,6 +1,7 @@
 from tablemusthave import Table
 from tablemusthave.musthave import AllGood, DoesntApply, StillNeeds
 from src.metadatalib.spec import allowed_file, specification
+from src.metadatalib.table import run_fixes
 
 
 def test_allowed_file():
@@ -24,7 +25,22 @@ def test_empty_metadata():
     for req, res in specification.check(
         Table(
             col_names,
-            [[None, None, None, None, None, None, None, None, None, None, None]],
+            [
+                [
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                ]
+            ],
         )
     ):
         print(req.description())
@@ -36,15 +52,22 @@ def test_empty_metadata():
 
 
 def test_bad_column_name():
-    for req, res in specification.check(
-        Table(col_names + ["bad_column*%^"], [g + [""] for g in good_samples])
-    ):
-        print(req.description())
-        print(res.message())
-        if isinstance(res, StillNeeds):
-            return
+    for bad in ["bad_column*%^", "bad.column"]:
+        for req, res in specification.check(
+            Table(col_names + [bad], [g + [""] for g in good_samples])
+        ):
+            print(req.description())
+            print(res.message())
+            if isinstance(res, StillNeeds):
+                break
+        else:
+            assert False
 
-    assert False
+
+def test_fix_column_name():
+    t = Table(col_names + ["bad.column"], [g + ["val1"] for g in good_samples])
+    run_fixes(t)
+    assert "badcolumn" in t.colnames()
 
 
 col_names = [
@@ -59,6 +82,7 @@ col_names = [
     "box_position",
     "study_group",
     "date_collected",
+    "time_collected",
 ]
 
 good_samples = [
@@ -74,6 +98,7 @@ good_samples = [
         "position1",
         "group1",
         "01-04-21",
+        "12:00:00",
     ],
     [
         "AnotherOne",
@@ -87,5 +112,6 @@ good_samples = [
         "position2",
         "group2",
         "06-07-23",
+        "12:00:00",
     ],
 ]

--- a/app/metadatalib/tests/test_spec.py
+++ b/app/metadatalib/tests/test_spec.py
@@ -2,6 +2,7 @@ from tablemusthave import Table
 from tablemusthave.musthave import AllGood, DoesntApply, StillNeeds
 from src.metadatalib.spec import allowed_file, specification
 from src.metadatalib.table import run_fixes
+import warnings
 
 
 def test_allowed_file():
@@ -68,6 +69,24 @@ def test_fix_column_name():
     t = Table(col_names + ["bad.column"], [g + ["val1"] for g in good_samples])
     run_fixes(t)
     assert "badcolumn" in t.colnames()
+
+
+def test_empty_column_name_fix():
+    t = Table(col_names + ["!!!"], [g + ["val1"] for g in good_samples])
+    run_fixes(t)
+    assert "unnamed_column" in t.colnames()
+
+
+def test_overwrite_column_name_warning():
+    t = Table(
+        col_names + ["bad.column", "badcolumn"],
+        [g + ["new1", "old1"] for g in good_samples],
+    )
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        run_fixes(t)
+        assert any("overwrites" in str(warn.message) for warn in w)
+    assert t.get("badcolumn") == ["new1", "new1"]
 
 
 col_names = [


### PR DESCRIPTION
## Summary
- restrict column names to alphanumeric characters, `_`, and `-`
- sanitize column names automatically when applying fixes
- cover new behavior with tests

## Testing
- `black app/metadatalib/tests/test_spec.py app/metadatalib/src/metadatalib/musthave.py app/metadatalib/src/metadatalib/spec.py -q`
- `PYTHONPATH=app/metadatalib/src pytest app/metadatalib/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_687a97507c0483238f2cdda60bc4cfcd