### PR TITLE
Add separate 16S, ITS, and UDI metadata specs

### DIFF
--- a/app/metadatalib/src/metadatalib/spec.py
+++ b/app/metadatalib/src/metadatalib/spec.py
@@ -97,8 +97,8 @@ tube_specs = [
     ),
 ]
 
-# Looser checks for internal samples, used in automation for munging metadata and merging barcodes
-internal_specs = [
+# Looser checks for UDI metadata sheets
+udi_specs = [
     columns_named(["SampleID", "sample_type"]),
     unique_values_for("plate", "plate_row", "plate_column"),
     some_value_for("plate", "plate_row"),
@@ -106,5 +106,11 @@ internal_specs = [
 ]
 
 
-specification = MustHave(*common_specs, *tube_specs)
-internal_specification = MustHave(*common_specs, *internal_specs)
+# Specifications for different metadata types
+specification_16s = MustHave(*common_specs, *tube_specs)
+specification_its = MustHave(*common_specs, *tube_specs)
+specification_udi = MustHave(*common_specs, *udi_specs)
+
+# Backwards compatibility
+specification = specification_16s
+internal_specification = specification_udi

--- a/app/metadatalib/src/metadatalib/table.py
+++ b/app/metadatalib/src/metadatalib/table.py
@@ -1,6 +1,9 @@
 from tablemusthave import Table, StillNeeds, MustHave
 from typing import Callable
-from metadatalib.spec import no_leading_trailing_whitespace, specification
+from metadatalib.spec import (
+    no_leading_trailing_whitespace,
+    specification_16s,
+)
 from metadatalib.consts import REGEX_TRANSLATE
 
 
@@ -14,7 +17,7 @@ except ImportError:
 
 def run_checks(
     t: Table,
-    specification: MustHave = specification,
+    specification: MustHave = specification_16s,
     flash: Callable[[str], None] = flash,
 ) -> tuple[Table, dict]:
     # Get metadata table to print on webpage
@@ -133,7 +136,7 @@ def run_checks(
     )
 
 
-def run_fixes(t: Table, specification: MustHave = specification):
+def run_fixes(t: Table, specification: MustHave = specification_16s):
     for h in t.colnames():
         specification.append(no_leading_trailing_whitespace(h))
     specification.fix(t)

--- a/app/metadatalib/tests/test_spec.py
+++ b/app/metadatalib/tests/test_spec.py
@@ -1,6 +1,6 @@
 from tablemusthave import Table
 from tablemusthave.musthave import AllGood, DoesntApply, StillNeeds
-from src.metadatalib.spec import allowed_file, specification
+from src.metadatalib.spec import allowed_file, specification_16s
 from src.metadatalib.table import run_fixes
 import warnings
 
@@ -16,14 +16,14 @@ def test_allowed_file():
 
 # Tests for the specification are not even close to comprehensive, in this case I think it's better to just be very attentive to the code given its declarative nature instead of having a million tests that need to be rewritten every time the specification changes
 def test_specification():
-    for req, res in specification.check(Table(col_names, good_samples)):
+    for req, res in specification_16s.check(Table(col_names, good_samples)):
         print(req.description())
         print(res.message())
         assert isinstance(res, AllGood) or isinstance(res, DoesntApply)
 
 
 def test_empty_metadata():
-    for req, res in specification.check(
+    for req, res in specification_16s.check(
         Table(
             col_names,
             [
@@ -54,7 +54,7 @@ def test_empty_metadata():
 
 def test_bad_column_name():
     for bad in ["bad_column*%^", "bad.column"]:
-        for req, res in specification.check(
+        for req, res in specification_16s.check(
             Table(col_names + [bad], [g + [""] for g in good_samples])
         ):
             print(req.description())


### PR DESCRIPTION
## Summary
- Break out specs into 16S, ITS, and UDI variants
- Use the 16S spec by default in table helpers
- Update tests to cover the new spec names

## Testing
- `black .`
- `PYTHONPATH=app/metadatalib/src pytest app/metadatalib/tests`


------
https://chatgpt.com/codex/tasks/task_e_689a282169b083239bbdefa89bd06be2