### PR TITLE
Avoid prefixing missing subject IDs

### DIFF
--- a/app/metadatalib/src/metadatalib/musthave.py
+++ b/app/metadatalib/src/metadatalib/musthave.py
@@ -66,7 +66,10 @@ def fix_sample_start(t: Table, colname: str, pattern: str):
 
 
 def fix_subject_start(t: Table, colname: str, pattern: str):
-    t.data[colname] = [f"SB{v}" for v in t.get(colname)]
+    regex = re.compile(pattern)
+    t.data[colname] = [
+        f"SB{v}" if v and not regex.match(v) else v for v in t.get(colname)
+    ]
 
 
 def fix_disallowed_sample_chars(t: Table, colname: str, pattern: str):

--- a/app/metadatalib/tests/test_musthave.py
+++ b/app/metadatalib/tests/test_musthave.py
@@ -1,0 +1,28 @@
+from tablemusthave import Table
+from src.metadatalib.musthave import fix_subject_start, fix_sample_start
+
+
+def test_fix_subject_start_skips_na_values():
+    t = Table(
+        ["subject_id"],
+        [
+            [None],
+            ["1"],
+            ["subject1"],
+        ],
+    )
+    fix_subject_start(t, "subject_id", "^[A-Za-z]")
+    assert t.get("subject_id") == [None, "SB1", "subject1"]
+
+
+def test_fix_sample_start_skips_na_values():
+    t = Table(
+        ["SampleID"],
+        [
+            [None],
+            ["1"],
+            ["SampleA"],
+        ],
+    )
+    fix_sample_start(t, "SampleID", "^[A-Za-z]")
+    assert t.get("SampleID") == [None, "S1", "SampleA"]


### PR DESCRIPTION
## Summary
- Avoid adding the "SB" prefix to missing `subject_id` entries.
- Test prefix fix behavior for subject and sample IDs when values are missing.

## Testing
- `black .`
- `pytest app/metadatalib/tests`


------
https://chatgpt.com/codex/tasks/task_e_68a89260117c8323be6dc7b475f992ee